### PR TITLE
fix: rename send notification email view

### DIFF
--- a/src/core/mail/mailer.ts
+++ b/src/core/mail/mailer.ts
@@ -31,7 +31,7 @@ export type MailerLoadRequest =
       };
     }
   | {
-      view: "notification";
+      view: "send-notification";
       props: {
         title: string;
         message: string;

--- a/src/core/use-cases/send-notification.ts
+++ b/src/core/use-cases/send-notification.ts
@@ -23,7 +23,7 @@ export class SendNotificationUseCase {
     const users = await this.usersRepository.list("basic", { role });
 
     const view = await this.mailer.load({
-      view: "notification",
+      view: "send-notification",
       props: { title, message },
     });
 


### PR DESCRIPTION
Corrige nome da view do e-mail de enviar notificações para "send-notification". Não é possível enviar uma notificação se o nome da view for apenas "notification", como estava.