### PR TITLE
refactor: add path parameters to swagger documentation for dynamic routes

### DIFF
--- a/src/infra/docs/swagger.ts
+++ b/src/infra/docs/swagger.ts
@@ -14,6 +14,7 @@ import { fetchCurrentBoxSchema } from "@/infra/http/controllers/fetch-current-bo
 import { fetchCurrentCatalogSchema } from "@/infra/http/controllers/fetch-current-catalog";
 import { fetchLastCatalogSchema } from "@/infra/http/controllers/fetch-last-catalog";
 import { fetchPendingsSchema } from "@/infra/http/controllers/fetch-pendings";
+import { fetchSalesReportSchema } from "@/infra/http/controllers/fetch-sales-report";
 import { handleBagSchema } from "@/infra/http/controllers/handle-bag";
 import { handleBoxSchema } from "@/infra/http/controllers/handle-box";
 import { handleFarmSchema } from "@/infra/http/controllers/handle-farm";
@@ -36,11 +37,10 @@ import { requestPasswordUpdateSchema } from "@/infra/http/controllers/request-pa
 import { sendNotificationSchema } from "@/infra/http/controllers/send-notification";
 import { updateCatalogSchema } from "@/infra/http/controllers/update-catalog";
 import { updateFarmSchema } from "@/infra/http/controllers/update-farm";
+import { updatePaymentSchema } from "@/infra/http/controllers/update-payment";
 import { updateProductSchema } from "@/infra/http/controllers/update-product";
 import { updateUserSchema } from "@/infra/http/controllers/update-user";
 import { verifyUserSchema } from "@/infra/http/controllers/verify-user";
-import { fetchSalesReportSchema } from "@/infra/http/controllers/fetch-sales-report";
-import { updatePaymentSchema } from "@/infra/http/controllers/update-payment";
 
 const tags = {
   users: "Usuários",
@@ -205,6 +205,17 @@ const docs = createDocument({
       },
     },
     "/farms/{farm_id}": {
+      parameters: [
+        {
+          in: "path",
+          name: "farm_id",
+          required: true,
+          schema: {
+            type: "string",
+            format: "uuid",
+          },
+        },
+      ],
       get: {
         tags: [tags.farms],
         responses: {
@@ -215,6 +226,17 @@ const docs = createDocument({
       },
     },
     "/farms/{farm_id}/handle": {
+      parameters: [
+        {
+          in: "path",
+          name: "farm_id",
+          required: true,
+          schema: {
+            type: "string",
+            format: "uuid",
+          },
+        },
+      ],
       patch: {
         tags: [tags.farms],
         responses: {
@@ -257,6 +279,17 @@ const docs = createDocument({
       },
     },
     "/boxes/{box_id}": {
+      parameters: [
+        {
+          in: "path",
+          name: "box_id",
+          required: true,
+          schema: {
+            type: "string",
+            format: "uuid",
+          },
+        },
+      ],
       get: {
         tags: [tags.boxes],
         responses: {
@@ -268,6 +301,17 @@ const docs = createDocument({
       },
     },
     "/boxes/{box_id}/handle": {
+      parameters: [
+        {
+          in: "path",
+          name: "box_id",
+          required: true,
+          schema: {
+            type: "string",
+            format: "uuid",
+          },
+        },
+      ],
       patch: {
         tags: [tags.boxes],
         responses: {
@@ -326,6 +370,17 @@ const docs = createDocument({
       },
     },
     "/catalogs/{catalog_id}": {
+      parameters: [
+        {
+          in: "path",
+          name: "catalog_id",
+          required: true,
+          schema: {
+            type: "string",
+            format: "uuid",
+          },
+        },
+      ],
       get: {
         tags: [tags.catalogs],
         responses: {
@@ -425,6 +480,17 @@ const docs = createDocument({
       },
     },
     "/bags/{bag_id}": {
+      parameters: [
+        {
+          in: "path",
+          name: "bag_id",
+          required: true,
+          schema: {
+            type: "string",
+            format: "uuid",
+          },
+        },
+      ],
       get: {
         tags: [tags.bags],
         responses: {
@@ -466,6 +532,17 @@ const docs = createDocument({
       },
     },
     "/bags/{bag_id}/pay": {
+      parameters: [
+        {
+          in: "path",
+          name: "bag_id",
+          required: true,
+          schema: {
+            type: "string",
+            format: "uuid",
+          },
+        },
+      ],
       post: {
         tags: [tags.payments],
         responses: {
@@ -481,6 +558,17 @@ const docs = createDocument({
       },
     },
     "/bags/{bag_id}/handle": {
+      parameters: [
+        {
+          in: "path",
+          name: "bag_id",
+          required: true,
+          schema: {
+            type: "string",
+            format: "uuid",
+          },
+        },
+      ],
       patch: {
         tags: [tags.bags],
         responses: { "204": { description: "204 OK" } },
@@ -490,6 +578,17 @@ const docs = createDocument({
       },
     },
     "/bags/{bag_id}/open": {
+      parameters: [
+        {
+          in: "path",
+          name: "bag_id",
+          required: true,
+          schema: {
+            type: "string",
+            format: "uuid",
+          },
+        },
+      ],
       post: {
         tags: [tags.payments],
         responses: {
@@ -530,6 +629,17 @@ const docs = createDocument({
     },
 
     "/products/{product_id}": {
+      parameters: [
+        {
+          in: "path",
+          name: "product_id",
+          required: true,
+          schema: {
+            type: "string",
+            format: "uuid",
+          },
+        },
+      ],
       patch: {
         tags: [tags.products],
         responses: { "204": { description: "204 OK" } },
@@ -568,6 +678,17 @@ const docs = createDocument({
     },
 
     "/payments/{payment_id}": {
+      parameters: [
+        {
+          in: "path",
+          name: "payment_id",
+          required: true,
+          schema: {
+            type: "string",
+            format: "uuid",
+          },
+        },
+      ],
       patch: {
         tags: [tags.payments],
         responses: { "204": { description: "204 OK" } },


### PR DESCRIPTION
This pull request includes changes to the `src/infra/docs/swagger.ts` file to add missing path parameters for various endpoints, in order to allow testing dynamic routes in the Swagger docs page.

### Path parameter additions:
* Added required `farm_id` path parameter to `/farms/{farm_id}` and `/farms/{farm_id}/handle` endpoints. [[1]](diffhunk://#diff-a6354b7b77ab6fe4d79dec821a7c034c461e93e3c8c95cb3604f359468403fb6R208-R218) [[2]](diffhunk://#diff-a6354b7b77ab6fe4d79dec821a7c034c461e93e3c8c95cb3604f359468403fb6R229-R239)
* Added required `box_id` path parameter to `/boxes/{box_id}` and `/boxes/{box_id}/handle` endpoints. [[1]](diffhunk://#diff-a6354b7b77ab6fe4d79dec821a7c034c461e93e3c8c95cb3604f359468403fb6R282-R292) [[2]](diffhunk://#diff-a6354b7b77ab6fe4d79dec821a7c034c461e93e3c8c95cb3604f359468403fb6R304-R314)
* Added required `catalog_id` path parameter to `/catalogs/{catalog_id}` endpoint.
* Added required `bag_id` path parameter to multiple `/bags/{bag_id}` endpoints, including `/bags/{bag_id}/pay`, `/bags/{bag_id}/handle`, and `/bags/{bag_id}/open`. [[1]](diffhunk://#diff-a6354b7b77ab6fe4d79dec821a7c034c461e93e3c8c95cb3604f359468403fb6R483-R493) [[2]](diffhunk://#diff-a6354b7b77ab6fe4d79dec821a7c034c461e93e3c8c95cb3604f359468403fb6R535-R545) [[3]](diffhunk://#diff-a6354b7b77ab6fe4d79dec821a7c034c461e93e3c8c95cb3604f359468403fb6R561-R571) [[4]](diffhunk://#diff-a6354b7b77ab6fe4d79dec821a7c034c461e93e3c8c95cb3604f359468403fb6R581-R591)
* Added required `product_id` path parameter to `/products/{product_id}` endpoint.
* Added required `payment_id` path parameter to `/payments/{payment_id}` endpoint.