### PR TITLE
fix(prisma-boxes-repository): add farm id selector in the where clause, and order the boxes' orders by product name

### DIFF
--- a/src/infra/database/repositories/prisma-boxes-repository.ts
+++ b/src/infra/database/repositories/prisma-boxes-repository.ts
@@ -30,6 +30,7 @@ export class PrismaBoxesRepository implements BoxesRepository {
           id: catalog?.id,
           cycle: { id: catalog?.cycle?.id },
           farm: {
+            id: catalog?.farm?.id,
             name: { contains: catalog?.farm?.name, mode: "insensitive" },
           },
         },
@@ -42,7 +43,7 @@ export class PrismaBoxesRepository implements BoxesRepository {
         ...(type === "merge" && {
           orders: {
             include: { offer: { include: { product: true } } },
-            orderBy: { created_at: "asc" },
+            orderBy: { offer: { product: { name: "asc" } } },
             ...(orders?.page && {
               skip: (orders.page - 1) * 20,
               take: 20,


### PR DESCRIPTION
This pull request includes changes to the `PrismaBoxesRepository` class to improve the filtering and ordering logic for catalog and orders.

Changes in filtering and ordering logic:

* [`src/infra/database/repositories/prisma-boxes-repository.ts`](diffhunk://#diff-1b7aa9db9b6ea53c853214b1099238dd27a8b6cf9d88b619a1b62047a3ce3e49R33): Added filtering by `id` for the `farm` object in the catalog.
* [`src/infra/database/repositories/prisma-boxes-repository.ts`](diffhunk://#diff-1b7aa9db9b6ea53c853214b1099238dd27a8b6cf9d88b619a1b62047a3ce3e49L45-R46): Changed the ordering of orders to be based on the product name instead of the creation date.