### PR TITLE
refactor: correct income calculations in farms sales report

### DIFF
--- a/src/infra/report/spreadsheet/views/farms-sales.ts
+++ b/src/infra/report/spreadsheet/views/farms-sales.ts
@@ -82,8 +82,8 @@ export const FARMS_PRODUCERS_VIEW: SpreadsheetView = async ({
         offer_price: offer.price + (offer.price * catalog.fee) / 100,
         fee: catalog.fee / 100,
         total_amount: amount,
-        total_price: amount * (offer.price + fee),
-        warehouse_price: amount * fee,
+        farm_income: amount * offer.price,
+        warehouse_income: amount * fee,
         since: since?.toLocaleDateString("pt-BR"),
         before: before?.toLocaleDateString("pt-BR"),
       });


### PR DESCRIPTION
This pull request includes changes to the `src/infra/report/spreadsheet/views/farms-sales.ts` file to correct the calculation of total prices and income.

Changes in financial calculations:

* [`src/infra/report/spreadsheet/views/farms-sales.ts`](diffhunk://#diff-c20098b75d4bffc64a3eff6d7948fd4a2fe4687b7a7c4d2cf305ce0027c73543L85-R86): Replaced `total_price` and `warehouse_price` with `farm_income` and `warehouse_income` to correctly represent the income calculations.