### PR TITLE
refactor: add order by name in product listing

### DIFF
--- a/src/infra/database/repositories/prisma-products-repository.ts
+++ b/src/infra/database/repositories/prisma-products-repository.ts
@@ -8,11 +8,11 @@ import { ProductsRepository, ProductsRepositorySearchRequest } from "@/core/repo
 import { prisma } from "@/infra/database/prisma-service";
 
 // Mappers
-import { PrismaProductMapper } from "@/infra/database/mappers/prisma-product-mapper";
 import { PrismaProductAndCategoryMapper } from "@/infra/database/mappers/prisma-product-and-category-mapper";
+import { PrismaProductMapper } from "@/infra/database/mappers/prisma-product-mapper";
 
 // Types
-import { ProductRepositoryReturnType, ProductEntityOf } from "@/core/repositories/products-repository";
+import { ProductEntityOf, ProductRepositoryReturnType } from "@/core/repositories/products-repository";
 
 export class PrismaProductRepository implements ProductsRepository {
   async find<T extends ProductRepositoryReturnType>(
@@ -53,6 +53,7 @@ export class PrismaProductRepository implements ProductsRepository {
     page?: number,
   ): Promise<ProductEntityOf<T>[]> {
     const products = await prisma.product.findMany({
+      orderBy: { name: "asc" },
       where: {
         id,
         pricing,


### PR DESCRIPTION
This pull request makes minor adjustments to the `PrismaProductRepository` class in `src/infra/database/repositories/prisma-products-repository.ts`, adding a default sorting order for product queries.

### Query behavior enhancements:
* Added a default sorting order (`orderBy: { name: "asc" }`) to the `findMany` query in `PrismaProductRepository`, ensuring products are returned in ascending order by name.