### PR TITLE
fix: removed extra +10 from total price in sales report

### DIFF
--- a/src/infra/report/pdf/views/sales-report.ejs
+++ b/src/infra/report/pdf/views/sales-report.ejs
@@ -315,7 +315,7 @@
           <div class="bag-info bag-info--cobrar">
             <p>Cobrar:</p>
             <h5>
-              R$ <%= (Number(parseFloat(bag.total)) + 10).toLocaleString("pt-BR", { minimumFractionDigits: 2 }) %>
+              R$ <%= (Number(parseFloat(bag.total))).toLocaleString("pt-BR", { minimumFractionDigits: 2 }) %>
             </h5>
           </div>
         </div>


### PR DESCRIPTION
This Pull request fixes a bug where the total price in the sales report was displaying an additional R$ 10, even in cases where the fee was not applicable.