### PR TITLE
fix: fixing character escaping on notification template

### DIFF
--- a/src/infra/mail/views/notification.ejs
+++ b/src/infra/mail/views/notification.ejs
@@ -151,7 +151,7 @@
         >
           <tr>
             <td class="content">
-              <p><%= props.text %></p>
+              <p><%- props.text.replace(/\n/g, "<br>") %></p>
               </p>
             </td>
           </tr>


### PR DESCRIPTION
<img width="515" height="565" alt="image" src="https://github.com/user-attachments/assets/9d30d68e-a2d8-4fb3-8b78-6a0ee2763976" />


https://app.clickup.com/t/86aag9vkr